### PR TITLE
fix: add default param values for CompleteRequest

### DIFF
--- a/Chapter09/KDetector/KDetector.cpp
+++ b/Chapter09/KDetector/KDetector.cpp
@@ -69,7 +69,9 @@ DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING) {
 	return status;
 }
 
-NTSTATUS CompleteRequest(PIRP Irp, NTSTATUS status, ULONG_PTR info) {
+NTSTATUS CompleteRequest(PIRP Irp,
+	NTSTATUS status = STATUS_SUCCESS,
+	ULONG_PTR info = 0) {
 	Irp->IoStatus.Status = status;
 	Irp->IoStatus.Information = info;
 	IoCompleteRequest(Irp, IO_NO_INCREMENT);


### PR DESCRIPTION
`CompleteRequest(Irp)` call on previous L80 will fail without the defaults.