### PR TITLE
fix(SysMon): update to ExAllocatePool2 [chap. 10]

### DIFF
--- a/Chapter10/SysMon/SysMon.cpp
+++ b/Chapter10/SysMon/SysMon.cpp
@@ -163,7 +163,7 @@ void OnProcessNotify(PEPROCESS Process, HANDLE ProcessId, PPS_CREATE_NOTIFY_INFO
 			commandLineSize = CreateInfo->CommandLine->Length;
 			allocSize += commandLineSize;
 		}
-		auto info = (FullItem<ProcessCreateInfo>*)ExAllocatePoolWithTag(PagedPool, allocSize, DRIVER_TAG);
+		auto info = (FullItem<ProcessCreateInfo>*)ExAllocatePool2(POOL_FLAG_PAGED, allocSize, DRIVER_TAG);
 		if (info == nullptr) {
 			KdPrint((DRIVER_PREFIX "failed allocation\n"));
 			return;
@@ -192,7 +192,7 @@ void OnProcessNotify(PEPROCESS Process, HANDLE ProcessId, PPS_CREATE_NOTIFY_INFO
 		//
 		// process exited
 		//
-		auto info = (FullItem<ProcessExitInfo>*)ExAllocatePoolWithTag(PagedPool, sizeof(FullItem<ProcessExitInfo>), DRIVER_TAG);
+		auto info = (FullItem<ProcessExitInfo>*)ExAllocatePool2(POOL_FLAG_PAGED, sizeof(FullItem<ProcessExitInfo>), DRIVER_TAG);
 		if (info == nullptr) {
 			KdPrint((DRIVER_PREFIX "failed allocation\n"));
 			return;
@@ -212,7 +212,7 @@ void OnProcessNotify(PEPROCESS Process, HANDLE ProcessId, PPS_CREATE_NOTIFY_INFO
 _Use_decl_annotations_
 void OnThreadNotify(HANDLE ProcessId, HANDLE ThreadId, BOOLEAN Create) {
 	auto size = Create ? sizeof(FullItem<ThreadCreateInfo>) : sizeof(FullItem<ThreadExitInfo>);
-	auto info = (FullItem<ThreadExitInfo>*)ExAllocatePoolWithTag(PagedPool, size, DRIVER_TAG);
+	auto info = (FullItem<ThreadExitInfo>*)ExAllocatePool2(POOL_FLAG_PAGED, size, DRIVER_TAG);
 	if (info == nullptr) {
 		KdPrint((DRIVER_PREFIX "Failed to allocate memory\n"));
 		return;
@@ -241,7 +241,7 @@ void OnImageLoadNotify(PUNICODE_STRING FullImageName, HANDLE ProcessId, PIMAGE_I
 	}
 
 	auto size = sizeof(FullItem<ImageLoadInfo>);
-	auto info = (FullItem<ImageLoadInfo>*)ExAllocatePoolWithTag(PagedPool, size, DRIVER_TAG);
+	auto info = (FullItem<ImageLoadInfo>*)ExAllocatePool2(POOL_FLAG_PAGED, size, DRIVER_TAG);
 	if (info == nullptr) {
 		KdPrint((DRIVER_PREFIX "Failed to allocate memory\n"));
 		return;
@@ -300,7 +300,7 @@ NTSTATUS OnRegistryNotify(PVOID context, PVOID arg1, PVOID arg2) {
 					//
 					USHORT valueSize = (USHORT)min(256, preInfo->DataSize);
 					size += keyNameLen + valueNameLen + valueSize;
-					auto info = (FullItem<RegistrySetValueInfo>*)ExAllocatePoolWithTag(PagedPool,
+					auto info = (FullItem<RegistrySetValueInfo>*)ExAllocatePool2(POOL_FLAG_PAGED,
 						size + sizeof(LIST_ENTRY), DRIVER_TAG);
 					if (info) {
 						auto& data = info->Data;


### PR DESCRIPTION
This updates all occurrences of `ExAllocatePoolWithTag` with  the new and hopefully final API: `ExAllocatePool2`.

--
Also while at it, can also update the source code in the text, pg. 335
![image](https://github.com/zodiacon/windowskernelprogrammingbook2e/assets/261265/87b8b702-3b69-400e-b238-223baa37d3c4)

--
I also see Chap. 9 is updated - https://github.com/zodiacon/windowskernelprogrammingbook2e/commit/d84839aa7961bdeeb6b52eb0ba91dc95c8165a56 👍 
