### PR TITLE
fix: minor fix in Tables.cpp

### DIFF
--- a/Chapter11/Tables/Tables.cpp
+++ b/Chapter11/Tables/Tables.cpp
@@ -55,7 +55,7 @@ NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING) {
 	if (!NT_SUCCESS(status)) {
 		if (procRegistered)
 			PsSetCreateProcessNotifyRoutineEx(OnProcessNotify, TRUE);
-		if (!symLinkCreated)
+		if (symLinkCreated)
 			IoDeleteSymbolicLink(&link);
 		if (devObj)
 			IoDeleteDevice(devObj);


### PR DESCRIPTION
fixes the logic for symbolic link deletion in driver entry.

--
Also fix in the text in pg. 359
![image](https://github.com/zodiacon/windowskernelprogrammingbook2e/assets/261265/20db0151-5f44-4240-9d5f-cd92343301ba)

