### PR TITLE
minor fix

### DIFF
--- a/Chapter10/KProtect/Protector.cpp
+++ b/Chapter10/KProtect/Protector.cpp
@@ -62,6 +62,7 @@ NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING) {
 			ObUnRegisterCallbacks(g_Data.RegHandle);
 		if (DeviceObject)
 			IoDeleteDevice(DeviceObject);
+		g_Data.Term();
 		return status;
 	}
 


### PR DESCRIPTION
call `g_Data.Term()` to release `ERESOURCE` when driver failed to load, or else `SYSTEM_SCAN_AT_RAISED_IRQL_CAUGHT_IMPROPER_DRIVER_UNLOAD` awaits.