### PR TITLE
Fix file size issue in Restore.cpp

### DIFF
--- a/Chapter12/Restore/Restore.cpp
+++ b/Chapter12/Restore/Restore.cpp
@@ -35,6 +35,8 @@ int wmain(int argc, const wchar_t* argv[]) {
 		return Error("Failed to allocate buffer");
 
 	DWORD bytes;
+	FILE_END_OF_FILE_INFO info;
+	info.EndOfFile = size;
 	while (size.QuadPart > 0) {
 		if (!ReadFile(hSource, buffer, (DWORD)(min((LONGLONG)bufferSize, size.QuadPart)), &bytes, nullptr))
 			return Error("Failed to read data");
@@ -43,6 +45,8 @@ int wmain(int argc, const wchar_t* argv[]) {
 			return Error("Failed to write data");
 		size.QuadPart -= bytes;
 	}
+
+	SetFileInformationByHandle(hTarget, FileEndOfFileInfo, (LPVOID)&info, sizeof(info));
 
 	printf("Restore successful!\n");
 


### PR DESCRIPTION
Hi Pavel.
Thanks for your daily sharing.

I noticed a issue about `Restore.cpp` for Chapter 12.
When a backup stream data size is smaller than size of the restoring file, it does not truncate the file size correctly as following:

```
PS C:\Works> Get-Content -Path $pwd\test.txt | Format-Hex


           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F

00000000   48 65 6C 6C 6F 2C 20 77 6F 72 6C 64 21           Hello, world!


PS C:\Works> Get-Content -Path $pwd\test.txt:backup | Format-Hex


           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F

00000000   68 69 20 3A 29                                   hi :)


PS C:\Works> .\Restore.exe $pwd\test.txt
Restore successful!
PS C:\Works> Get-Content -Path $pwd\test.txt | Format-Hex


           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F

00000000   68 69 20 3A 29 2C 20 77 6F 72 6C 64 21           hi :), world!


PS C:\Works>
```

I fixed this issue, and confirmed as this:

```
PS C:\Works> Get-Content -Path $pwd\test.txt | Format-Hex


           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F

00000000   48 65 6C 6C 6F 2C 20 77 6F 72 6C 64 21           Hello, world!


PS C:\Works> Get-Content -Path $pwd\test.txt:backup | Format-Hex


           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F

00000000   68 69 20 3A 29                                   hi :)


PS C:\Works> .\Restore_new.exe $pwd\test.txt
Restore successful!
PS C:\Works> Get-Content -Path $pwd\test.txt | Format-Hex


           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F

00000000   68 69 20 3A 29                                   hi :)


PS C:\Works>
```